### PR TITLE
Line-number fix on linux machines

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -55,6 +55,7 @@
       text-indent: 0.5em;
       padding-right: 0.5em;
       opacity: 1;
+      text-align: left;
       .icon-right {
         opacity: 1;
         padding: 0 2px 0 0;


### PR DESCRIPTION
Lines without arrows next to them are out of place (more to the right) since their alignment is center
this commit fixes this.

Before fix:
![Imgur](http://i.imgur.com/IZQCZH5.png)

After fix:
![Imgur](http://i.imgur.com/hLkdmlW.png)
