### PR TITLE
Added settings, and setting to toggle colorless icons in tabs

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,18 @@
+module.exports =
+  config:
+    colourlessIcons:
+      type: 'boolean'
+      default: true
+      description: "Tick to force colourless tab icons"
+  activate: (state) ->
+    varKey = 'predawn-ui.colourlessIcons'
+    self = @
+    atom.config.onDidChange varKey, ({newValue, oldValue}) ->
+      self.setColoured(newValue)
+    @setColoured(atom.config.get(varKey))
+  setColoured: (enable) ->
+    tabBar = document.querySelector('.tab-bar')
+    if !enable
+      tabBar.className = tabBar.className.replace(/\scolourless-icons/, '')
+    else
+      tabBar.className = tabBar.className + " " + 'colourless-icons'

--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -3,7 +3,11 @@
   line-height: @tab-height;
   background-color: @tab-bar-background-color;
 
-
+  &.colourless-icons {
+    .tab .title:before {
+      color: rgba(255,255,255,0.25) !important;
+    }
+  }
 
   .tab {
     display: inline-block;
@@ -18,9 +22,6 @@
 
     .title {
       opacity: @text-color-subtle;
-      &:before {
-        color: rgba(255,255,255,0.25) !important;
-      }
     }
 
     &:first-child {


### PR DESCRIPTION
I love predawn but want to use colored tab icons such as file-icons. Since predawn defaults to overriding these styles I added an option in the package settings to toggle colored/colorless tab icons. Don't worry, it's defaulted to colorless, so the out-of-box experience is the same.
Colorless
![Colorless](https://cloud.githubusercontent.com/assets/6582067/5154819/88ee5f30-723c-11e4-88c0-a7fa1d0c8faa.png)
Colored
![Colored](https://cloud.githubusercontent.com/assets/6582067/5154822/91a57d8e-723c-11e4-9109-e4cc5d568b37.png)


