### PR TITLE
Improve settings

### DIFF
--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -13,3 +13,7 @@
     box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px fade(@text-color-highlight, 60%);
   }
 }
+
+.settings-view atom-text-editor[mini] {
+  background-color: @input-background-color;
+}

--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -5,7 +5,11 @@
   background-color: @text-color-highlight;
 }
 
-.form-control:focus {
-  border-color: lighten(@text-color-highlight, 10%);
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px fade(@text-color-highlight, 60%);
+.settings-view select.form-control {
+  box-shadow: none;
+  background: rgba(255,255,255,.08);
+  &:focus {
+    border-color: lighten(@text-color-highlight, 10%);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px fade(@text-color-highlight, 60%);
+  }
 }

--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -1,6 +1,7 @@
 @import "ui-variables";
 
 .settings-view .config-menu .nav > li.active > a {
+  color: white;
   background-color: @text-color-highlight;
 }
 


### PR DESCRIPTION
Soon the Atom settings will use the `ui-variables` to match a theme's look and feel: https://github.com/atom/settings-view/pull/277 This PR fixes a few things and will look like this:

![screen shot 2014-12-18 at 4 12 32 pm](https://cloud.githubusercontent.com/assets/378023/5484719/5957cc76-86d1-11e4-9899-7f183414f513.png)
