### PR TITLE
slightly darker text-color-selected

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -91,3 +91,11 @@ autocomplete-suggestion-list .icon-container {
 autocomplete-suggestion-list.select-list.popover-list ol.list-group li {
   color: #fff;
 }
+
+.select-list.command-palette {
+  .list-group {
+    .character-match {
+      color: @text-color-selected;
+    }
+  }
+}

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -9,7 +9,7 @@
 @text-color: rgba(255, 255, 255, 0.8);
 @text-color-subtle: rgba(255, 255, 255, 0.5);
 @text-color-highlight: #f18260;
-@text-color-selected: @text-color-highlight;
+@text-color-selected: #cf5c3f;
 
 @text-color-info: #5293d8;
 @text-color-success: #26c26a;


### PR DESCRIPTION
this should address #28 

made the text-color-selected a touch darker by tweaking `@text-color-selected`

This also affects code completion and other bits but seems good everywhere by my aesthetic.
