### PR TITLE
correct search highlight

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -7,7 +7,7 @@
     color: #fff;
 
     &:before {
-      background-color: @text-color-highlight;
+      background-color: fade(@app-background-color, 30%);
       z-index: -1;
     }
   }
@@ -108,7 +108,7 @@ autocomplete-suggestion-list.select-list.popover-list ol.list-group li {
 .select-list.command-palette {
   .list-group {
     .character-match {
-      color: @text-color-selected;
+      color: @text-color-highlight;
     }
   }
 }
@@ -135,7 +135,8 @@ autocomplete-suggestion-list.select-list.popover-list ol.list-group li {
       }
     }
     .character-match {
-      color: @text-color-selected;
+      color: @text-color-highlight;
+      border-bottom: 1px dotted @text-color-highlight;
     }
   }
 }


### PR DESCRIPTION
whaddap, @jamiewilson !

I could barely read the highlighted search results.
what do you think of this?

__before__
![correct-search-highlight before](https://cloud.githubusercontent.com/assets/462507/22878572/a13d1246-f1da-11e6-863b-0e2af858ace7.png)


__after__

![correct-search-highlight after](https://cloud.githubusercontent.com/assets/462507/22878574/a3cf2c4c-f1da-11e6-82f8-44b5fa758416.png)
